### PR TITLE
Change license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,90 +1,201 @@
-GaussianSplatting.jl
-===========================
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-This software is a derivative work on [Gaussian Splatting algorithm](https://github.com/graphdeco-inria/gaussian-splatting).
-Users of this code must comply with the original license terms found in the
-[Gaussian Splatting license](https://github.com/graphdeco-inria/gaussian-splatting/blob/main/LICENSE.md).
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Gaussian Splatting
-===========================
+   1. Definitions.
 
-**Inria** and **the Max Planck Institut for Informatik (MPII)** hold all the ownership rights on the *Software* named **gaussian-splatting**.
-The *Software* is in the process of being registered with the Agence pour la Protection des
-Programmes (APP).
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-The *Software* is still being developed by the *Licensor*.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-*Licensor*'s goal is to allow the research community to use, test and evaluate
-the *Software*.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-## 1.  Definitions
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-*Licensee* means any person or entity that uses the *Software* and distributes
-its *Work*.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-*Licensor* means the owners of the *Software*, i.e Inria and MPII
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-*Software* means the original work of authorship made available under this
-License ie gaussian-splatting.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-*Work* means the *Software* and any additions to or derivative works of the
-*Software* that are made available under this License.
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-## 2.  Purpose
-This license is intended to define the rights granted to the *Licensee* by
-Licensors under the *Software*.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-## 3.  Rights granted
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-For the above reasons Licensors have decided to distribute the *Software*.
-Licensors grant non-exclusive rights to use the *Software* for research purposes
-to research users (both academic and industrial), free of charge, without right
-to sublicense.. The *Software* may be used "non-commercially", i.e., for research
-and/or evaluation purposes only.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-Subject to the terms and conditions of this License, you are granted a
-non-exclusive, royalty-free, license to reproduce, prepare derivative works of,
-publicly display, publicly perform and distribute its *Work* and any resulting
-derivative works in any form.
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-## 4.  Limitations
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-**4.1 Redistribution.** You may reproduce or distribute the *Work* only if (a) you do
-so under this License, (b) you include a complete copy of this License with
-your distribution, and (c) you retain without modification any copyright,
-patent, trademark, or attribution notices that are present in the *Work*.
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-**4.2 Derivative Works.** You may specify that additional or different terms apply
-to the use, reproduction, and distribution of your derivative works of the *Work*
-("Your Terms") only if (a) Your Terms provide that the use limitation in
-Section 2 applies to your derivative works, and (b) you identify the specific
-derivative works that are subject to Your Terms. Notwithstanding Your Terms,
-this License (including the redistribution requirements in Section 3.1) will
-continue to apply to the *Work* itself.
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-**4.3** Any other use without of prior consent of Licensors is prohibited. Research
-users explicitly acknowledge having received from Licensors all information
-allowing to appreciate the adequacy between of the *Software* and their needs and
-to undertake all necessary precautions for its execution and use.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-**4.4** The *Software* is provided both as a compiled library file and as source
-code. In case of using the *Software* for a publication or other results obtained
-through the use of the *Software*, users are strongly encouraged to cite the
-corresponding publications as explained in the documentation of the *Software*.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-## 5.  Disclaimer
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-THE USER CANNOT USE, EXPLOIT OR DISTRIBUTE THE *SOFTWARE* FOR COMMERCIAL PURPOSES
-WITHOUT PRIOR AND EXPLICIT CONSENT OF LICENSORS. YOU MUST CONTACT INRIA FOR ANY
-UNAUTHORIZED USE: stip-sophia.transfert@inria.fr . ANY SUCH ACTION WILL
-CONSTITUTE A FORGERY. THIS *SOFTWARE* IS PROVIDED "AS IS" WITHOUT ANY WARRANTIES
-OF ANY NATURE AND ANY EXPRESS OR IMPLIED WARRANTIES, WITH REGARDS TO COMMERCIAL
-USE, PROFESSIONNAL USE, LEGAL OR NOT, OR OTHER, OR COMMERCIALISATION OR
-ADAPTATION. UNLESS EXPLICITLY PROVIDED BY LAW, IN NO EVENT, SHALL INRIA OR THE
-AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES, LOSS OF USE, DATA, OR PROFITS OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE *SOFTWARE* OR THE USE OR OTHER DEALINGS IN THE *SOFTWARE*.
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/GaussianSplatting.jl
+++ b/src/GaussianSplatting.jl
@@ -1,9 +1,5 @@
 # Copyright © 2024 Advanced Micro Devices, Inc. All rights reserved.
-# This software is free for non-commercial, research and evaluation use
-# under the terms of the LICENSE.md file.
 module GaussianSplatting
-
-using VideoIO
 
 using Adapt
 using ChainRulesCore
@@ -25,6 +21,7 @@ using ImageCore
 using ImageIO
 using ImageTransformations
 using FileIO
+using VideoIO
 using Zygote
 
 using NeuralGraphicsGL

--- a/src/camera.jl
+++ b/src/camera.jl
@@ -1,6 +1,4 @@
 # Copyright © 2024 Advanced Micro Devices, Inc. All rights reserved.
-# This software is free for non-commercial, research and evaluation use
-# under the terms of the LICENSE.md file.
 mutable struct Camera
     R::SMatrix{3, 3, Float32, 9}
     t::SVector{3, Float32}

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -1,6 +1,4 @@
 # Copyright © 2024 Advanced Micro Devices, Inc. All rights reserved.
-# This software is free for non-commercial, research and evaluation use
-# under the terms of the LICENSE.md file.
 struct ColmapDataset{
     P <: AbstractMatrix{Float32},
     C <: AbstractMatrix{Float32},

--- a/src/gaussians.jl
+++ b/src/gaussians.jl
@@ -1,6 +1,4 @@
 # Copyright © 2024 Advanced Micro Devices, Inc. All rights reserved.
-# This software is free for non-commercial, research and evaluation use
-# under the terms of the LICENSE.md file.
 mutable struct GaussianModel{
     P <: AbstractMatrix{Float32},
     R <: AbstractVector{Int32},

--- a/src/gui/camera_path.jl
+++ b/src/gui/camera_path.jl
@@ -1,6 +1,4 @@
 # Copyright © 2024 Advanced Micro Devices, Inc. All rights reserved.
-# This software is free for non-commercial, research and evaluation use
-# under the terms of the LICENSE.md file.
 Base.@kwdef mutable struct CameraPath
     keyframes::Vector{NU.CameraKeyframe} = []
     current_time::Float32 = 0f0

--- a/src/gui/capture_mode.jl
+++ b/src/gui/capture_mode.jl
@@ -1,6 +1,4 @@
 # Copyright © 2024 Advanced Micro Devices, Inc. All rights reserved.
-# This software is free for non-commercial, research and evaluation use
-# under the terms of the LICENSE.md file.
 Base.@kwdef mutable struct CaptureMode
     camera_path::CameraPath = CameraPath()
     writer::Union{VideoIO.VideoWriter, Nothing} = nothing

--- a/src/gui/gui.jl
+++ b/src/gui/gui.jl
@@ -1,6 +1,4 @@
 # Copyright © 2024 Advanced Micro Devices, Inc. All rights reserved.
-# This software is free for non-commercial, research and evaluation use
-# under the terms of the LICENSE.md file.
 include("ui_state.jl")
 include("render_state.jl")
 include("camera_path.jl")

--- a/src/gui/render_state.jl
+++ b/src/gui/render_state.jl
@@ -1,6 +1,4 @@
 # Copyright © 2024 Advanced Micro Devices, Inc. All rights reserved.
-# This software is free for non-commercial, research and evaluation use
-# under the terms of the LICENSE.md file.
 Base.@kwdef mutable struct RenderState
     surface::NeuralGraphicsGL.RenderSurface
     need_render::Bool = true # `true` to trigger first frame rendering

--- a/src/gui/ui_state.jl
+++ b/src/gui/ui_state.jl
@@ -1,6 +1,4 @@
 # Copyright © 2024 Advanced Micro Devices, Inc. All rights reserved.
-# This software is free for non-commercial, research and evaluation use
-# under the terms of the LICENSE.md file.
 Base.@kwdef mutable struct UIState
     train::Ref{Bool} = Ref(false)
     render::Ref{Bool} = Ref(true)

--- a/src/rasterization/rasterizer.jl
+++ b/src/rasterization/rasterizer.jl
@@ -1,6 +1,4 @@
 # Copyright © 2024 Advanced Micro Devices, Inc. All rights reserved.
-# This software is free for non-commercial, research and evaluation use
-# under the terms of the LICENSE.md file.
 include("states.jl")
 include("utils.jl")
 

--- a/src/rasterization/states.jl
+++ b/src/rasterization/states.jl
@@ -1,6 +1,4 @@
 # Copyright © 2024 Advanced Micro Devices, Inc. All rights reserved.
-# This software is free for non-commercial, research and evaluation use
-# under the terms of the LICENSE.md file.
 struct GeometryState{
     D <: AbstractVector{Float32},
     M <: AbstractVector{SVector{2, Float32}},

--- a/src/rasterization/utils.jl
+++ b/src/rasterization/utils.jl
@@ -1,6 +1,4 @@
 # Copyright © 2024 Advanced Micro Devices, Inc. All rights reserved.
-# This software is free for non-commercial, research and evaluation use
-# under the terms of the LICENSE.md file.
 sdiagm(x, y, z) = SMatrix{3, 3, Float32, 9}(
     x, 0f0, 0f0,
     0f0, y, 0f0,

--- a/src/training.jl
+++ b/src/training.jl
@@ -1,6 +1,4 @@
 # Copyright © 2024 Advanced Micro Devices, Inc. All rights reserved.
-# This software is free for non-commercial, research and evaluation use
-# under the terms of the LICENSE.md file.
 mutable struct Trainer{
     R <: GaussianRasterizer,
     G <: GaussianModel,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,4 @@
 # Copyright © 2024 Advanced Micro Devices, Inc. All rights reserved.
-# This software is free for non-commercial, research and evaluation use
-# under the terms of the LICENSE.md file.
 Base.@kwdef struct OptimizationParams
     λ_dssim::Float32 = 0.2f0
 


### PR DESCRIPTION
After #14 the rasterizer has been completely rewritten, so I believe it is safe to change the license to Apache-2.0.

To clarify, that after the public release of this package, I am the sole developer and is not affiliated with AMD, so any complains should be directed at me.