### PR TITLE
Make alpha-map differentiable

### DIFF
--- a/src/GaussianSplatting.jl
+++ b/src/GaussianSplatting.jl
@@ -238,6 +238,7 @@ function benchmark(kab, dataset_path::String;
             n_gaussians=length(gaussians), loss,
             ssim=eval_ssim, mse=eval_mse, psnr=eval_psnr))
 
+        # TODO (AMDGPU.jl) bulk-freeing in finalizers triggers use-after-free?
         # Release GPU memory before the next run. Synchronize around the
         # frees: no in-flight kernel may touch the buffers being released &
         # any async fault from this run surfaces here, inside its config.

--- a/src/depth_supervision.jl
+++ b/src/depth_supervision.jl
@@ -350,28 +350,34 @@ function depth_target(anchor::DepthAnchor, prior::AbstractMatrix{Float32}, qstep
 end
 
 """
-Scale-and-shift-invariant depth loss on the rendered blended depth `D`.
+Scale-and-shift-invariant depth loss on the rendered blended depth `D`
+and the rendered alpha map `alpha`.
 
 The rendered value is the alpha-normalized expected depth `e = D / α`
-mapped to softened inverse depth `p = 1/(e + floor)`; `α = 1 - T` is
-treated as a constant (the backward has no alpha-map input), so
-gradients flow to the Gaussians only through the depth map.
+mapped to softened inverse depth `p = 1/(e + floor)`. Both `D` and `α`
+are differentiable rasterizer outputs, so the quotient rule feeds an
+alpha cotangent back into the backward and the depth loss shapes Gaussian opacity directly.
+
+The weights & normalizations built from `α` stay detached:
+supervision pressure should not leak in through its own weighting.
+
 Data term: alpha-weighted Geman-McClure penalty on the deadbanded
 residual, scaled by the alpha-weighted std of `p` (detached).
 Gradient term: same penalty on the mismatch of forward-difference
-gradients (MiDaS-style), aligning depth edges rather than absolute
-values. The sum is normalized by the total alpha.
+gradients (MiDaS-style), aligning depth edges rather than absolute values.
+
+The sum is normalized by the total alpha.
 """
 function ssi_depth_loss(
-    depth_img::AbstractMatrix{Float32};
-    transmittance::AbstractMatrix{Float32},
+    depth_img::AbstractMatrix{Float32},
+    alpha::AbstractMatrix{Float32};
     target::AbstractMatrix{Float32},
     half_band::AbstractMatrix{Float32},
     valid::AbstractMatrix{Bool},
     depth_floor::Float32,
     λ_grad::Float32 = DEPTH_LOSS_GRADIENT_WEIGHT,
 )
-    α = ignore_derivatives(clamp.(1f0 .- transmittance, 0f0, 1f0))
+    α = clamp.(alpha, 0f0, 1f0)
     w = ignore_derivatives(ifelse.(valid .& (α .> DEPTH_LOSS_MIN_ALPHA), α, 0f0))
     Σα = ignore_derivatives(max(sum(α), 1f0))
 

--- a/src/rasterization/rasterizer.jl
+++ b/src/rasterization/rasterizer.jl
@@ -59,7 +59,8 @@ function GaussianRasterizer(kab;
     scales_act = KA.allocate(kab, Float32, (3, 0))
     opacities_act = KA.allocate(kab, Float32, (1, 0))
 
-    image = KA.allocate(kab, Float32, (mode == :rgbd ? 4 : 3, width, height))
+    # :rgbd renders 5 channels: rgb, depth & the alpha map (see `GeometryState`).
+    image = KA.allocate(kab, Float32, (mode == :rgbd ? 5 : 3, width, height))
     host_image, pinned_image = allocate_pinned(kab, Float32, (3, width, height))
 
     rast = GaussianRasterizer(
@@ -197,7 +198,13 @@ function (rast::GaussianRasterizer)(
         colors = spherical_harmonics(means_3d, shs; rast, camera, sh_degree)
 
         color_features = if rast.mode == :rgbd
-            vcat(colors, reshape(depths, 1, :))
+            # Constant-1 row renders the alpha map (see `GeometryState`);
+            # `ignore_derivatives` stops its (meaningless) cotangent from the
+            # `vcat` pullback, while its effect on opacities/means/conics
+            # flows through the `vα` path of `∇render!`.
+            ones_row = ignore_derivatives(
+                KA.ones(get_backend(rast), Float32, (1, length(depths))))
+            vcat(colors, reshape(depths, 1, :), ones_row)
         else
             colors
         end
@@ -340,7 +347,8 @@ function rasterize(
     color_features = if render_depth
         rast.gstate.color_features[1:3, :] .= reshape(reinterpret(Float32, rast.gstate.rgbs), 3, :)
         rast.gstate.color_features[4, :] .= rast.gstate.depths
-        _as_T(SVector{4, Float32}, rast.gstate.color_features)
+        rast.gstate.color_features[5, :] .= 1f0 # Constant feature: renders the alpha map.
+        _as_T(SVector{5, Float32}, rast.gstate.color_features)
     else
         rast.gstate.rgbs
     end
@@ -357,7 +365,8 @@ function rasterize(
         color_features,
         rast.istate.ranges,
         SVector{2, Int32}(width, height),
-        render_depth ? SVector{4, Float32}(background..., 0f0) : background,
+        # Zero background for the depth & alpha channels.
+        render_depth ? SVector{5, Float32}(background..., 0f0, 0f0) : background,
         BLOCK, Val(BLOCK_SIZE))
     return rast.image
 end
@@ -381,7 +390,7 @@ function ∇rasterize(
     (; width, height) = resolution(camera)
     @assert width % 16 == 0 && height % 16 == 0
 
-    vcolor_features = KA.zeros(kab, Float32, (render_depth ? 4 : 3, n))
+    vcolor_features = KA.zeros(kab, Float32, (render_depth ? 5 : 3, n))
     vconics = KA.zeros(kab, Float32, (3, n))
     vcov = KA.zeros(kab, Float32, (6, n))
 
@@ -396,7 +405,7 @@ function ∇rasterize(
     (; width, height) = resolution(camera)
 
     color_features = render_depth ?
-        _as_T(SVector{4, Float32}, rast.gstate.color_features) :
+        _as_T(SVector{5, Float32}, rast.gstate.color_features) :
         rast.gstate.rgbs
 
     ∇render!(kab, (Int.(BLOCK)...,), (width, height))(
@@ -407,7 +416,7 @@ function ∇rasterize(
         reshape(reinterpret(Float32, rast.gstate.∇means_2d), 2, :),
         # Inputs.
         reshape(
-            reinterpret(SVector{render_depth ? 4 : 3, Float32}, vpixels),
+            reinterpret(SVector{render_depth ? 5 : 3, Float32}, vpixels),
             size(vpixels)[2:3]),
         rast.istate.n_contrib,
         rast.istate.accum_α,
@@ -420,9 +429,13 @@ function ∇rasterize(
 
         rast.istate.ranges,
         SVector{2, Int32}(width, height),
-        render_depth ? SVector{4, Float32}(background..., 0f0) : background,
+        render_depth ? SVector{5, Float32}(background..., 0f0, 0f0) : background,
         rast.grid, BLOCK, Val(BLOCK_SIZE))
 
+    # Row 5 of `vcolor_features` is the cotangent of the constant-1 alpha
+    # feature: dropped (the feature is not a parameter). The alpha map's
+    # effect on opacities/means/conics is already accumulated by `∇render!`
+    # through the per-channel `vα` path.
     vrgbs, vdepths = if render_depth
         vcolor_features[1:3, :], vcolor_features[4, :]
     else

--- a/src/rasterization/render.jl
+++ b/src/rasterization/render.jl
@@ -417,7 +417,10 @@ end
                 last_color[c] = color[c]
                 vα += (color[c] - accum_rec[c]) * vpixel[c]
             end
-            vα *= T # TODO mull by vaccum_α when supporting :rgbed mode
+            # The alpha-map cotangent needs no special handling here: the map
+            # is rendered as a constant-1 feature channel, so it enters `vα`
+            # through the generic per-channel loop above.
+            vα *= T
             # Account for the fact that `α` also influences how
             # much of the background is added.
             vα += (-T_final / (1f0 - α)) * (bg_color ⋅ vpixel)

--- a/src/rasterization/states.jl
+++ b/src/rasterization/states.jl
@@ -31,7 +31,10 @@ GeometryState(kab, n::Int; extended::Bool = false) = GeometryState(
     KA.zeros(kab, Int32, n),
     KA.zeros(kab, SVector{3, Float32}, n),
     KA.zeros(kab, Int32, n),
-    extended ? KA.zeros(kab, Float32, (4, n)) : nothing)
+    # rgb + depth + constant-1 alpha feature: `Σᵢ 1·αᵢ·Tᵢ = 1 - T_final`,
+    # so the 5th channel renders the alpha map & the standard per-channel
+    # backward yields its exact gradient (the `grad_alpha` path).
+    extended ? KA.zeros(kab, Float32, (5, n)) : nothing)
 
 Base.length(gstate::GeometryState) = length(gstate.depths)
 

--- a/src/training.jl
+++ b/src/training.jl
@@ -299,8 +299,8 @@ function step!(trainer::Trainer)
 
             if depth_data ≢ nothing
                 depth_img = image_features[4, :, :]
-                total += depth_data.weight * ssi_depth_loss(depth_img;
-                    transmittance=rast.istate.accum_α,
+                alpha_img = image_features[5, :, :]
+                total += depth_data.weight * ssi_depth_loss(depth_img, alpha_img;
                     depth_data.target, depth_data.half_band, depth_data.valid,
                     depth_floor=anchor.floor)
             end


### PR DESCRIPTION
The alpha map is now rendered as a 5th image channel using a constant-1 feature per Gaussian. Since Σᵢ 1·αᵢ·Tᵢ is exactly `1 − T_final`, channel 5 equals the alpha map that `ssi_depth_loss` previously read from `istate.accum_α` as a detached side channel.